### PR TITLE
Add aerodynamics and buoyancy to VA pod

### DIFF
--- a/GameData/KOSMOS/Parts/Command/Kosmos_VA_RRV_Capsule/part.cfg
+++ b/GameData/KOSMOS/Parts/Command/Kosmos_VA_RRV_Capsule/part.cfg
@@ -31,6 +31,13 @@ node_stack_top00 = 0, 0.610394848125, 0, 0, 1, 0, 1 //Parachute point
 node_stack_bottom = 0, -0.887187423125, 0, 0, -1, 0, 2 //Lockdown point
 node_stack_top02 = 0, 0.732410125, 0, 0, 1, 0, 1 //VA RCS tower point
 
+CoPOffset = 0.0, 0.5, 0.0
+CoLOffset = 0.0, -0.35, 0.0
+CenterOfBuoyancy = 0.0, 0.5, 0.0
+CenterOfDisplacement = 0.0, -0.3, 0.0
+buoyancy = 1.5
+buoyancyUseSine = False
+
 // --- editor parameters ---
 TechRequired = specializedControl
 entryCost = 9400


### PR DESCRIPTION
This fixes the VA pod's tendency to point the wrong way during reentry and adds some small buoyancy changes to make the pod float better.
